### PR TITLE
Fix metric compute and controller input

### DIFF
--- a/closed_loop.py
+++ b/closed_loop.py
@@ -82,7 +82,7 @@ def create_gym_env(cfg, output):
             'obj_names': ['car' for _ in info['obj_boxes']],
             'planned_traj': {
                 'traj': global_traj,
-                'timestep': 0.25
+                'timestep': 0.5
             },
             'collision': info['collision'],
             'rc': info['rc']

--- a/sim/utils/score_calculator.py
+++ b/sim/utils/score_calculator.py
@@ -233,7 +233,7 @@ class ScoreCalculator:
                         cnt += 1
             drivable_ratio = cnt / (m*n)
             if drivable_ratio < 0.3:
-                return 0
+                return 0.0
             elif drivable_ratio < 0.5:
                 dac = 0.5
         return dac
@@ -258,7 +258,7 @@ class ScoreCalculator:
                     cnt += 1
         drivable_ratio = cnt / (m*n)
         if drivable_ratio < 0.3:
-            return 0
+            return 0.0
         elif drivable_ratio < 0.5:
             dac = 0.5
         return dac
@@ -315,7 +315,7 @@ class ScoreCalculator:
         checks = [
             np.all(np.abs(kinematics['lat_accel']) <=
                    boundaries['max_abs_lat_accel']),
-            np.all(kinematics['lon_accel'] <= boundaries['max_abs_lat_accel']),
+            np.all(kinematics['lon_accel'] <= boundaries['max_lon_accel']),
             np.all(kinematics['lon_accel'] >= boundaries['min_lon_accel']),
             np.all(np.abs(kinematics['lon_jerk']) <=
                    boundaries['max_abs_lon_jerk']),

--- a/sim/utils/sim_utils.py
+++ b/sim/utils/sim_utils.py
@@ -59,10 +59,11 @@ def traj2control(plan_traj, info):
     plan_traj_stats[1:, :2] = plan_traj[:, [1,0]]
     prev_a, prev_b = 0, 0
     for i, (a, b) in enumerate(plan_traj):
-        rot = np.arctan((b - prev_b)/(a - prev_a))
+        rot = np.arctan2(b - prev_b, np.abs(a - prev_a)) * np.sign(a - prev_a)
         plan_traj_stats[i+1, 2] = rot
+        prev_a, prev_b = a, b
     curr_stat = np.array(
-        [0, 0, 0, info['ego_velo'], info['ego_steer']]
+        [0.0, 0.0, 0.0, info['ego_velo'], info['ego_steer']]
     )
     acc, steer_rate = plan2control(plan_traj_stats, curr_stat)
     return acc, steer_rate

--- a/sim/utils/sim_utils.py
+++ b/sim/utils/sim_utils.py
@@ -57,9 +57,11 @@ def traj2control(plan_traj, info):
     """
     plan_traj_stats = np.zeros((plan_traj.shape[0]+1, 5))
     plan_traj_stats[1:, :2] = plan_traj[:, [1,0]]
-    prev_a, prev_b = 0, 0
+    prev_a, prev_b = 0.0, 0.0
     for i, (a, b) in enumerate(plan_traj):
-        rot = np.arctan2(b - prev_b, np.abs(a - prev_a)) * np.sign(a - prev_a)
+        rot = np.arctan2(b - prev_b, a - prev_a)
+        rot = np.where(rot > np.pi/2, rot - np.pi, rot)
+        rot = np.where(rot < -np.pi/2, rot + np.pi, rot)
         plan_traj_stats[i+1, 2] = rot
         prev_a, prev_b = a, b
     curr_stat = np.array(


### PR DESCRIPTION
Summary
- This PR resolves several potential issues in the closed-loop metric computation and simulation pipeline to improve consistency and numerical stability.

Changes
- Acceleration bound: Replaces `max_abs_lat_accel` with `max_lon_accel` to correctly apply the predefined longitudinal acceleration bounds used by the comfort (COM) scoring function.
- Trajectory timestep: Increases the planned trajectory timestep from 0.25 s to 0.5 s, aligning with controller's parameter https://github.com/hyzhou404/HUGSIM/blob/4dd2d284e0a25508f0f7c8156a98f7c9b90792fb/sim/ilqr/lqr.py#L4-L6 and the conventional prediction timestep used by the baseline models. (related to #47)
- Heading estimation: Refines the heading computation for the predicted trajectory input to the controller. 
  - The heading is now estimated with respect to the previous trajectory point instead of the initial position.
  - A more stable adapted arctan2 formulation is used instead of arctan, preventing division-by-zero issue.