### PR TITLE
Fix heading computation to ensure consistent coordinate order with poses

### DIFF
--- a/sim/utils/sim_utils.py
+++ b/sim/utils/sim_utils.py
@@ -58,7 +58,7 @@ def traj2control(plan_traj, info):
     plan_traj_stats = np.zeros((plan_traj.shape[0]+1, 5))
     plan_traj_stats[1:, :2] = plan_traj[:, [1,0]]
     prev_a, prev_b = 0.0, 0.0
-    for i, (a, b) in enumerate(plan_traj):
+    for i, (b, a) in enumerate(plan_traj):
         rot = np.arctan2(b - prev_b, a - prev_a)
         rot = np.where(rot > np.pi/2, rot - np.pi, rot)
         rot = np.where(rot < -np.pi/2, rot + np.pi, rot)


### PR DESCRIPTION
This PR corrects the heading computation so that it is consistent with the coordinate system used for trajectory poses in vehicle coordinates.
The heading should be computed as
`heading = arctan2(lateral_displacement, forward_displacement)`,
where `lateral_displacement = plan_traj[:, 0]` and `forward_displacement = plan_traj[:, 1]`.

In the original implementation (and even earlier in the unsafe `arctan` version before the PR #56) the arguments of `arctan2` were swapped, effectively producing an angle equal to `π/2 – heading`.

This fix restores the proper geometric interpretation of the poses, improves simulation fidelity, and leads to higher evaluation scores across different methods.